### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "async": "~0.2.9",
-    "caesar": "~1.0.4",
     "date.js": "~0.1.1",
     "human-interval": "~0.1.3",
     "lodash": "~2.4.1",


### PR DESCRIPTION
martinet fails to install on node v0.10.X due to msgpack failing to compile for older versions of node. Since it's unused, consider removing it.
